### PR TITLE
Filepicker

### DIFF
--- a/app/src/main/java/com/rifters/riftedreader/ui/library/LibraryFragment.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/library/LibraryFragment.kt
@@ -3,11 +3,13 @@ package com.rifters.riftedreader.ui.library
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.provider.Settings
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
@@ -17,13 +19,21 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.snackbar.Snackbar
 import com.rifters.riftedreader.R
 import com.rifters.riftedreader.data.database.BookDatabase
 import com.rifters.riftedreader.data.repository.BookRepository
 import com.rifters.riftedreader.databinding.FragmentLibraryBinding
 import com.rifters.riftedreader.ui.reader.ReaderActivity
 import com.rifters.riftedreader.util.FileScanner
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.IOException
+import java.util.Locale
+import android.provider.OpenableColumns
+import android.os.Environment
 
 class LibraryFragment : Fragment() {
     
@@ -40,6 +50,19 @@ class LibraryFragment : Fragment() {
             viewModel.scanForBooks()
         } else {
             showPermissionDeniedDialog()
+        }
+    }
+    private val manageStoragePermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        checkPermissionAndScan()
+    }
+
+    private val importBookLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            importBookFromUri(uri)
         }
     }
     
@@ -90,7 +113,7 @@ class LibraryFragment : Fragment() {
     
     private fun setupFab() {
         binding.scanFab.setOnClickListener {
-            checkPermissionAndScan()
+            showAddBooksMenu()
         }
     }
     
@@ -110,11 +133,24 @@ class LibraryFragment : Fragment() {
                         binding.progressIndicator.visibility = if (isScanning) View.VISIBLE else View.GONE
                     }
                 }
+
+                launch {
+                    viewModel.events.collect { event ->
+                        handleLibraryEvent(event)
+                    }
+                }
             }
         }
     }
     
     private fun checkPermissionAndScan() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (!Environment.isExternalStorageManager()) {
+                showAllFilesAccessDialog()
+                return
+            }
+        }
+
         val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             Manifest.permission.READ_MEDIA_IMAGES
         } else {
@@ -154,6 +190,146 @@ class LibraryFragment : Fragment() {
             .setMessage(R.string.permission_storage_message)
             .setPositiveButton(R.string.ok, null)
             .show()
+    }
+
+    private fun showAllFilesAccessDialog() {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.permission_all_files_title)
+            .setMessage(R.string.permission_all_files_message)
+            .setPositiveButton(R.string.permission_open_settings) { _, _ ->
+                openAllFilesAccessSettings()
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    private fun openAllFilesAccessSettings() {
+        val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+            data = Uri.parse("package:${requireContext().packageName}")
+        }
+        manageStoragePermissionLauncher.launch(intent)
+    }
+
+    private fun showAddBooksMenu() {
+        val options = arrayOf(
+            getString(R.string.library_action_scan),
+            getString(R.string.library_action_import)
+        )
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.library_add_books_title)
+            .setItems(options) { _, which ->
+                when (which) {
+                    0 -> checkPermissionAndScan()
+                    1 -> openFilePicker()
+                }
+            }
+            .show()
+    }
+
+    private fun openFilePicker() {
+        val mimeTypes = arrayOf(
+            "application/epub+zip",
+            "application/pdf",
+            "text/plain"
+        )
+        importBookLauncher.launch(mimeTypes)
+    }
+
+    private fun importBookFromUri(uri: Uri) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                runCatching { copyUriToInternalStorage(uri) }
+            }
+
+            val fileWithName = result.getOrNull()
+            if (fileWithName == null) {
+                Snackbar.make(binding.root, R.string.library_import_copy_failed, Snackbar.LENGTH_LONG).show()
+                return@launch
+            }
+
+            val (file, displayName) = fileWithName
+            viewModel.importBook(file, displayName)
+        }
+    }
+
+    private fun copyUriToInternalStorage(uri: Uri): Pair<File, String> {
+        val resolver = requireContext().contentResolver
+        val displayName = resolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor ->
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (cursor.moveToFirst() && index >= 0) cursor.getString(index) else null
+            }
+
+        val safeName = sanitizeFileName(displayName ?: generateFallbackName(uri))
+        val destinationDir = File(requireContext().filesDir, "imports").apply { mkdirs() }
+        val finalName = ensureUniqueName(destinationDir, appendExtensionIfMissing(safeName, uri))
+        val destination = File(destinationDir, finalName)
+
+        resolver.openInputStream(uri)?.use { input ->
+            destination.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        } ?: throw IOException("Unable to open input stream")
+
+        return destination to (displayName ?: destination.name)
+    }
+
+    private fun appendExtensionIfMissing(fileName: String, uri: Uri): String {
+        val current = fileName
+        val hasExtension = current.contains('.')
+        if (hasExtension) return current
+        val mime = requireContext().contentResolver.getType(uri)
+        val extension = when (mime?.lowercase(Locale.getDefault())) {
+            "application/epub+zip" -> "epub"
+            "application/pdf" -> "pdf"
+            "text/plain" -> "txt"
+            else -> null
+        }
+        return if (extension != null) "$current.$extension" else current
+    }
+
+    private fun ensureUniqueName(directory: File, fileName: String): String {
+        var candidate = fileName
+        var counter = 1
+        val base = fileName.substringBeforeLast('.', fileName)
+        val extension = fileName.substringAfterLast('.', "")
+        while (File(directory, candidate).exists()) {
+            candidate = if (extension.isEmpty()) {
+                "${base}_$counter"
+            } else {
+                "${base}_$counter.$extension"
+            }
+            counter++
+        }
+        return candidate
+    }
+
+    private fun sanitizeFileName(name: String): String {
+        return name.replace(Regex("[\\/:*?\"<>|]"), "_").trim().ifEmpty { "book" }
+    }
+
+    private fun generateFallbackName(uri: Uri): String {
+        val mime = requireContext().contentResolver.getType(uri)
+        val extension = when (mime?.lowercase(Locale.getDefault())) {
+            "application/epub+zip" -> "epub"
+            "application/pdf" -> "pdf"
+            "text/plain" -> "txt"
+            else -> "book"
+        }
+        return "import_${System.currentTimeMillis()}${if (extension == "book") "" else ".$extension"}"
+    }
+
+    private fun handleLibraryEvent(event: LibraryEvent) {
+        val message = when (event) {
+            is LibraryEvent.ImportSuccess -> getString(R.string.library_import_success, event.title)
+            is LibraryEvent.ImportUnsupported -> getString(R.string.library_import_unsupported, event.name)
+            LibraryEvent.ImportFailed -> getString(R.string.library_import_failed)
+            is LibraryEvent.Duplicate -> getString(R.string.library_import_duplicate, event.title)
+            is LibraryEvent.ScanCompleted -> getString(R.string.library_scan_completed, event.count)
+            LibraryEvent.ScanNoNewBooks -> getString(R.string.library_scan_no_new_books)
+            LibraryEvent.ScanFailed -> getString(R.string.library_scan_failed)
+        }
+        Snackbar.make(binding.root, message, Snackbar.LENGTH_LONG).show()
     }
     
     override fun onDestroyView() {

--- a/app/src/main/java/com/rifters/riftedreader/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/library/LibraryViewModel.kt
@@ -4,12 +4,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rifters.riftedreader.data.database.entities.BookMeta
 import com.rifters.riftedreader.data.repository.BookRepository
+import com.rifters.riftedreader.domain.parser.ParserFactory
 import com.rifters.riftedreader.util.FileScanner
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.Dispatchers
+import java.io.File
 
 class LibraryViewModel(
     private val repository: BookRepository,
@@ -24,6 +30,9 @@ class LibraryViewModel(
     
     private val _scanProgress = MutableStateFlow(Pair(0, 0))
     val scanProgress: StateFlow<Pair<Int, Int>> = _scanProgress.asStateFlow()
+
+    private val _events = MutableSharedFlow<LibraryEvent>()
+    val events: SharedFlow<LibraryEvent> = _events
     
     // Track the active Flow collection job to cancel when needed
     private var booksCollectionJob: Job? = null
@@ -47,9 +56,16 @@ class LibraryViewModel(
         viewModelScope.launch {
             _isScanning.value = true
             try {
-                fileScanner.scanForBooks { scanned, found ->
+                val added = fileScanner.scanForBooks { scanned, found ->
                     _scanProgress.value = Pair(scanned, found)
                 }
+                if (added.isEmpty()) {
+                    _events.emit(LibraryEvent.ScanNoNewBooks)
+                } else {
+                    _events.emit(LibraryEvent.ScanCompleted(added.size))
+                }
+            } catch (e: Exception) {
+                _events.emit(LibraryEvent.ScanFailed)
             } finally {
                 _isScanning.value = false
             }
@@ -76,4 +92,41 @@ class LibraryViewModel(
             repository.deleteBook(book)
         }
     }
+
+    fun importBook(file: File, displayName: String? = null) {
+        viewModelScope.launch {
+            try {
+                val parser = ParserFactory.getParser(file)
+                if (parser == null) {
+                    file.delete()
+                    _events.emit(LibraryEvent.ImportUnsupported(displayName ?: file.name))
+                    return@launch
+                }
+
+                val existing = repository.getBookByPath(file.absolutePath)
+                if (existing != null) {
+                    file.delete()
+                    _events.emit(LibraryEvent.Duplicate(existing.title.ifBlank { displayName ?: existing.path }))
+                    return@launch
+                }
+
+                val metadata = withContext(Dispatchers.IO) { parser.extractMetadata(file) }
+                repository.insertBook(metadata)
+                _events.emit(LibraryEvent.ImportSuccess(metadata.title.ifBlank { displayName ?: file.name }))
+            } catch (e: Exception) {
+                file.delete()
+                _events.emit(LibraryEvent.ImportFailed)
+            }
+        }
+    }
+}
+
+sealed interface LibraryEvent {
+    data class ImportSuccess(val title: String) : LibraryEvent
+    data class ImportUnsupported(val name: String) : LibraryEvent
+    object ImportFailed : LibraryEvent
+    data class Duplicate(val title: String) : LibraryEvent
+    data class ScanCompleted(val count: Int) : LibraryEvent
+    object ScanNoNewBooks : LibraryEvent
+    object ScanFailed : LibraryEvent
 }

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -70,8 +70,8 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="16dp"
-        android:contentDescription="@string/scan_books"
-        app:srcCompat="@android:drawable/ic_menu_search" />
+        android:contentDescription="@string/library_add_books_title"
+        app:srcCompat="@android:drawable/ic_input_add" />
 
     <com.google.android.material.progressindicator.LinearProgressIndicator
         android:id="@+id/progressIndicator"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,7 +14,18 @@
     <string name="filter">Filter</string>
     <string name="scan_books">Scan for books</string>
     <string name="no_books_found">No books found</string>
-    <string name="add_books_message">Add books to your library by scanning your device</string>
+    <string name="add_books_message">Add books by scanning your device or importing a file</string>
+    <string name="library_add_books_title">Add books</string>
+    <string name="library_action_scan">Scan device</string>
+    <string name="library_action_import">Import from file</string>
+    <string name="library_scan_completed">Added %1$d new books</string>
+    <string name="library_scan_no_new_books">No new books found</string>
+    <string name="library_scan_failed">Scanning failed. Try again.</string>
+    <string name="library_import_success"><![CDATA[Added "%1$s"]]></string>
+    <string name="library_import_unsupported"><![CDATA["%1$s" is not a supported format]]></string>
+    <string name="library_import_failed">Could not add that book. Try again.</string>
+    <string name="library_import_duplicate"><![CDATA["%1$s" is already in your library]]></string>
+    <string name="library_import_copy_failed">Could not copy the selected file</string>
     
     <!-- Reader -->
     <string name="chapter">Chapter %1$d</string>
@@ -86,6 +97,9 @@
     <string name="permission_storage_message">RiftedReader needs access to your storage to read ebook files.</string>
     <string name="permission_grant">Grant Permission</string>
     <string name="permission_denied">Permission Denied</string>
+    <string name="permission_all_files_title">Allow full storage access</string>
+    <string name="permission_all_files_message">RiftedReader needs "All files access" to scan your storage for books. You can also import books manually.</string>
+    <string name="permission_open_settings">Open settings</string>
     
     <!-- Common -->
     <string name="ok">OK</string>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an import-from-file option with a new add-books menu, improves scan flow with events/snackbars and MANAGE_ALL_FILES_ACCESS handling, and expands default scan directories.
> 
> - **UI (LibraryFragment & layout)**
>   - Add add-books menu triggered by FAB to either `scan` or `import` files; update FAB icon/description.
>   - Implement file import via system picker, copying to internal `files/imports/` with safe, unique naming and inferred extensions.
>   - Show user feedback via `Snackbar` for import/scan outcomes; observe `events` flow.
>   - Handle Android 11+ "All files access" prompt and settings intent before scanning; refine permission rationale/denied dialogs.
> - **ViewModel (LibraryViewModel)**
>   - Introduce `LibraryEvent` shared flow for import/scan results (success, duplicate, unsupported, no new books, failed).
>   - `scanForBooks` now reports added count and emits events; `importBook` validates format, duplicates, extracts metadata, inserts, and emits events.
> - **Utilities (FileScanner)**
>   - Expand default scan directories (Downloads, Documents, Audiobooks, Books, ebooks, RiftedReader, app-specific).
>   - Return list of found books and respect repository checks while scanning.
> - **Resources**
>   - Add strings for add-books actions, import/scan messages, and full storage access prompts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 110611b7da9439815302a59de6df748f5b1826e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->