### PR TITLE
Propagate TTS highlighting into paged reader mode

### DIFF
--- a/.vscode/markdown-preview.css
+++ b/.vscode/markdown-preview.css
@@ -1,0 +1,26 @@
+body {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+
+a {
+    color: #80cbc4;
+}
+
+code, pre {
+    background-color: #1e1e1e;
+    color: #f8f8f2;
+}
+
+blockquote {
+    background-color: #1b1b1b;
+    border-left: 4px solid #80cbc4;
+}
+
+table {
+    background-color: #1b1b1b;
+}
+
+table tr:nth-child(even) {
+    background-color: #222222;
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "markdown.styles": [
+        ".vscode/markdown-preview.css"
+    ]
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.preference:preference-ktx:1.2.1")
+    implementation("androidx.viewpager2:viewpager2:1.0.0")
     
     // Architecture Components
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")

--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt
@@ -1,0 +1,148 @@
+package com.rifters.riftedreader.ui.reader
+
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.BackgroundColorSpan
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.text.HtmlCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.rifters.riftedreader.R
+import com.rifters.riftedreader.databinding.FragmentReaderPageBinding
+import kotlinx.coroutines.launch
+
+class ReaderPageFragment : Fragment() {
+
+    private var _binding: FragmentReaderPageBinding? = null
+    private val binding get() = _binding!!
+
+    private val readerViewModel: ReaderViewModel by activityViewModels()
+
+    private val pageIndex: Int by lazy {
+        requireArguments().getInt(ARG_PAGE_INDEX)
+    }
+
+    private var latestPageText: String = ""
+    private var latestPageHtml: String? = null
+    private var highlightedRange: IntRange? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentReaderPageBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                readerViewModel.pages.collect { pages ->
+                    val page = pages.getOrNull(pageIndex)
+                    if (page != null) {
+                        latestPageText = page.text
+                        latestPageHtml = page.html
+                        if (highlightedRange == null) {
+                            renderBaseContent()
+                        } else {
+                            applyHighlight(highlightedRange)
+                        }
+                    } else {
+                        latestPageText = ""
+                        latestPageHtml = null
+                        highlightedRange = null
+                        binding.pageTextView.text = ""
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                readerViewModel.highlight.collect { highlight ->
+                    if (highlight?.pageIndex == pageIndex) {
+                        highlightedRange = highlight.range
+                        applyHighlight(highlight.range)
+                    } else if (highlightedRange != null && highlight?.pageIndex != pageIndex) {
+                        highlightedRange = null
+                        renderBaseContent()
+                    }
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                readerViewModel.readerSettings.collect { settings ->
+                    binding.pageTextView.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, settings.textSizeSp)
+                    binding.pageTextView.setLineSpacing(0f, settings.lineHeightMultiplier)
+                    val palette = ReaderThemePaletteResolver.resolve(requireContext(), settings.theme)
+                    binding.root.setBackgroundColor(palette.backgroundColor)
+                    binding.pageTextView.setTextColor(palette.textColor)
+                }
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun applyHighlight(range: IntRange?) {
+        if (_binding == null) return
+        if (range == null) {
+            renderBaseContent()
+            return
+        }
+        if (latestPageText.isBlank()) {
+            binding.pageTextView.text = latestPageText
+            return
+        }
+        if (range.first < 0 || range.first >= latestPageText.length) {
+            renderBaseContent()
+            return
+        }
+        val spannable = SpannableString(latestPageText)
+        val endExclusive = (range.last + 1).coerceAtMost(spannable.length)
+        val highlightColor = ContextCompat.getColor(requireContext(), R.color.reader_tts_highlight)
+        spannable.setSpan(
+            BackgroundColorSpan(highlightColor),
+            range.first,
+            endExclusive,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        binding.pageTextView.text = spannable
+    }
+
+    private fun renderBaseContent() {
+        if (_binding == null) return
+        val html = latestPageHtml
+        if (!html.isNullOrBlank()) {
+            binding.pageTextView.text = HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY)
+        } else {
+            binding.pageTextView.text = latestPageText
+        }
+    }
+
+    companion object {
+        private const val ARG_PAGE_INDEX = "arg_page_index"
+
+        fun newInstance(pageIndex: Int): ReaderPageFragment {
+            return ReaderPageFragment().apply {
+                arguments = Bundle().apply {
+                    putInt(ARG_PAGE_INDEX, pageIndex)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPagerAdapter.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPagerAdapter.kt
@@ -1,0 +1,26 @@
+package com.rifters.riftedreader.ui.reader
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+class ReaderPagerAdapter(
+    activity: FragmentActivity
+) : FragmentStateAdapter(activity) {
+
+    private var pageCount: Int = 0
+
+    override fun getItemCount(): Int = pageCount
+
+    override fun createFragment(position: Int): Fragment {
+        return ReaderPageFragment.newInstance(position)
+    }
+
+    fun submitPageCount(count: Int) {
+        if (pageCount == count) {
+            return
+        }
+        pageCount = count
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderThemePalette.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderThemePalette.kt
@@ -1,0 +1,27 @@
+package com.rifters.riftedreader.ui.reader
+
+import android.content.Context
+import androidx.core.content.ContextCompat
+import com.rifters.riftedreader.R
+import com.rifters.riftedreader.data.preferences.ReaderTheme
+
+data class ReaderThemePalette(
+    val backgroundColor: Int,
+    val textColor: Int
+)
+
+internal object ReaderThemePaletteResolver {
+
+    fun resolve(context: Context, theme: ReaderTheme): ReaderThemePalette {
+        val (backgroundRes, textRes) = when (theme) {
+            ReaderTheme.DARK -> R.color.reader_background_dark to R.color.reader_text_dark
+            ReaderTheme.SEPIA -> R.color.reader_background_sepia to R.color.reader_text_sepia
+            ReaderTheme.BLACK -> R.color.reader_background_black to R.color.reader_text_black
+            ReaderTheme.LIGHT -> R.color.reader_background_light to R.color.reader_text_light
+        }
+        return ReaderThemePalette(
+            backgroundColor = ContextCompat.getColor(context, backgroundRes),
+            textColor = ContextCompat.getColor(context, textRes)
+        )
+    }
+}

--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderViewModel.kt
@@ -8,10 +8,13 @@ import com.rifters.riftedreader.data.preferences.ReaderSettings
 import com.rifters.riftedreader.data.repository.BookRepository
 import com.rifters.riftedreader.domain.parser.BookParser
 import com.rifters.riftedreader.domain.parser.PageContent
+import com.rifters.riftedreader.domain.parser.TxtParser
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 class ReaderViewModel(
@@ -22,14 +25,20 @@ class ReaderViewModel(
     readerPreferences: ReaderPreferences
 ) : ViewModel() {
     
+    private val _pages = MutableStateFlow<List<PageContent>>(emptyList())
+    val pages: StateFlow<List<PageContent>> = _pages.asStateFlow()
+
     private val _content = MutableStateFlow(PageContent.EMPTY)
     val content: StateFlow<PageContent> = _content.asStateFlow()
-    
+
     private val _currentPage = MutableStateFlow(0)
     val currentPage: StateFlow<Int> = _currentPage.asStateFlow()
-    
+
     private val _totalPages = MutableStateFlow(0)
     val totalPages: StateFlow<Int> = _totalPages.asStateFlow()
+
+    private val _highlight = MutableStateFlow<TtsHighlight?>(null)
+    val highlight: StateFlow<TtsHighlight?> = _highlight.asStateFlow()
 
     val readerSettings: StateFlow<ReaderSettings> = readerPreferences.settings
 
@@ -50,58 +59,145 @@ class ReaderViewModel(
     }
     
     init {
-        loadBookInfo()
+        buildPagination()
     }
-    
-    private fun loadBookInfo() {
+
+    private fun buildPagination() {
         viewModelScope.launch {
             try {
                 val book = repository.getBookById(bookId)
-                if (book != null) {
-                    _currentPage.value = book.currentPage
+                val savedPage = book?.currentPage ?: 0
+
+                val pages = withContext(Dispatchers.IO) { generatePages() }
+
+                _pages.value = pages
+                _totalPages.value = pages.size
+
+                val initialPage = if (pages.isNotEmpty()) {
+                    savedPage.coerceIn(0, pages.lastIndex)
+                } else {
+                    0
                 }
-                
-                val pageCount = parser.getPageCount(bookFile)
-                _totalPages.value = pageCount
+                _currentPage.value = initialPage
+                _content.value = pages.getOrNull(initialPage) ?: PageContent.EMPTY
             } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-    }
-    
-    fun loadCurrentPage() {
-        viewModelScope.launch {
-            try {
-                val pageContent = parser.getPageContent(bookFile, _currentPage.value)
-                _content.value = pageContent
-            } catch (e: Exception) {
+                _pages.value = emptyList()
+                _totalPages.value = 0
+                _currentPage.value = 0
                 _content.value = PageContent(text = "Error loading content: ${e.message}")
                 e.printStackTrace()
             }
         }
     }
-    
-    fun nextPage() {
-        if (_currentPage.value < _totalPages.value - 1) {
-            _currentPage.value += 1
-            loadCurrentPage()
+
+    private suspend fun generatePages(): List<PageContent> {
+        return withContext(Dispatchers.IO) {
+            val pages = mutableListOf<PageContent>()
+            val rawPageCount = parser.getPageCount(bookFile).coerceAtLeast(0)
+
+            // For TXT we already paginate by fixed line counts, reuse as-is.
+            if (parser is TxtParser) {
+                for (index in 0 until rawPageCount) {
+                    val pageContent = runCatching { parser.getPageContent(bookFile, index) }
+                        .getOrDefault(PageContent.EMPTY)
+                    pages += pageContent
+                }
+                return@withContext pages
+            }
+
+            // Generic fallback: treat each parser "page" (chapter/spine) and further split it.
+            for (index in 0 until rawPageCount) {
+                val chapterContent = runCatching { parser.getPageContent(bookFile, index) }
+                    .getOrDefault(PageContent.EMPTY)
+                pages += splitChapterContent(chapterContent)
+            }
+
+            if (pages.isEmpty()) {
+                listOf(PageContent.EMPTY)
+            } else {
+                pages
+            }
         }
     }
-    
-    fun previousPage() {
-        if (_currentPage.value > 0) {
-            _currentPage.value -= 1
-            loadCurrentPage()
+
+    private fun splitChapterContent(content: PageContent): List<PageContent> {
+        val text = content.text.trim()
+        if (text.isBlank()) {
+            return emptyList()
         }
-    }
-    
-    fun goToPage(page: Int) {
-        if (page in 0 until _totalPages.value) {
-            _currentPage.value = page
-            loadCurrentPage()
+
+        if (text.length <= TARGET_CHARS_PER_PAGE) {
+            return listOf(content)
         }
+
+        val normalized = text.replace('\n', ' ').replace("\r", " ")
+        val words = normalized.split(Regex("\\s+"))
+        if (words.isEmpty()) {
+            return listOf(content)
+        }
+
+        val pages = mutableListOf<PageContent>()
+        val builder = StringBuilder()
+        for (word in words) {
+            if (builder.length + word.length + 1 > TARGET_CHARS_PER_PAGE && builder.isNotBlank()) {
+                pages += PageContent(text = builder.toString().trim())
+                builder.clear()
+            }
+            if (builder.isNotEmpty()) {
+                builder.append(' ')
+            }
+            builder.append(word)
+        }
+
+        if (builder.isNotBlank()) {
+            pages += PageContent(text = builder.toString().trim())
+        }
+
+        return pages
     }
-    
+
+    fun nextPage(): Boolean {
+        val pages = _pages.value
+        if (pages.isEmpty()) return false
+        val current = _currentPage.value
+        if (current >= pages.lastIndex) {
+            return false
+        }
+        updateCurrentPage(current + 1)
+        return true
+    }
+
+    fun previousPage(): Boolean {
+        val pages = _pages.value
+        if (pages.isEmpty()) return false
+        val current = _currentPage.value
+        if (current <= 0) {
+            return false
+        }
+        updateCurrentPage(current - 1)
+        return true
+    }
+
+    fun goToPage(page: Int): Boolean {
+        val pages = _pages.value
+        if (pages.isEmpty()) return false
+        if (page !in 0..pages.lastIndex) {
+            return false
+        }
+        updateCurrentPage(page)
+        return true
+    }
+
+    fun hasNextPage(): Boolean {
+        val pages = _pages.value
+        if (pages.isEmpty()) return false
+        return _currentPage.value < pages.lastIndex
+    }
+
+    fun hasPreviousPage(): Boolean {
+        return _currentPage.value > 0
+    }
+
     fun saveProgress() {
         viewModelScope.launch {
             try {
@@ -115,4 +211,31 @@ class ReaderViewModel(
             }
         }
     }
+
+    private fun updateCurrentPage(index: Int) {
+        val pages = _pages.value
+        if (pages.isEmpty()) {
+            _currentPage.value = 0
+            _content.value = PageContent.EMPTY
+            return
+        }
+        val safeIndex = index.coerceIn(0, pages.lastIndex)
+        _currentPage.value = safeIndex
+        _content.value = pages.getOrNull(safeIndex) ?: PageContent.EMPTY
+    }
+
+    fun publishHighlight(pageIndex: Int, range: IntRange?) {
+        _highlight.value = TtsHighlight(pageIndex, range)
+    }
+
+    companion object {
+        private const val TARGET_CHARS_PER_PAGE = 1800
+    }
 }
+
+private fun StringBuilder.isNotBlank(): Boolean = this.any { !it.isWhitespace() }
+
+data class TtsHighlight(
+    val pageIndex: Int,
+    val range: IntRange?
+)

--- a/app/src/main/res/layout/activity_reader.xml
+++ b/app/src/main/res/layout/activity_reader.xml
@@ -13,6 +13,7 @@
         android:layout_height="match_parent"
         android:clipToPadding="false"
         android:paddingBottom="96dp"
+        android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -29,6 +30,17 @@
             tools:text="Book content goes here..." />
 
     </ScrollView>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/pageViewPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="96dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/controlsContainer"

--- a/app/src/main/res/layout/fragment_reader_page.xml
+++ b/app/src/main/res/layout/fragment_reader_page.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/pageTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:lineSpacingExtra="4dp"
+        android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+        android:textColor="@android:color/white"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a paged reader mode using ViewPager2, precomputed pagination, and synchronizes TTS sentence highlighting across pages, with updated UI/layout and theme handling.
> 
> - **Reader UI/UX**:
>   - **Paged Mode**: Adds ViewPager2-based paged reading via `ReaderPagerAdapter` and `ReaderPageFragment`, with gesture handling and page slider sync.
>   - **TTS Integration**: Propagates sentence highlight to paged mode via `ReaderViewModel.publishHighlight` and updates on `TTSStatusNotifier` events; optional auto-continue to next page when TTS reaches end.
>   - **Theme**: Centralizes theme colors with `ReaderThemePaletteResolver`; applies to scroll and paged views.
>   - **Controls**: Reworks next/prev navigation (`navigateToNextPage`/`navigateToPreviousPage`), page indicator bounds, and mode toggling between `SCROLL` and `PAGE`.
> - **ViewModel**:
>   - **Pagination**: Precomputes pages (`pages` `StateFlow`), calculates `totalPages`, and loads initial content; splits non-TXT content into ~1800-char pages.
>   - **API**: Adds boolean-returning `nextPage`/`previousPage`/`goToPage`, `hasNextPage`/`hasPreviousPage`, and `publishHighlight`; manages `highlight` stream.
> - **Layouts**:
>   - Updates `activity_reader.xml` to include `ViewPager2` and visibility toggling with `ScrollView`.
>   - Adds `fragment_reader_page.xml` for per-page content.
> - **Dependencies**:
>   - Adds `androidx.viewpager2:viewpager2:1.0.0`.
> - **Tooling**:
>   - Adds `.vscode/markdown-preview.css` and `.vscode/settings.json` for markdown preview styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6681c2d569cf716e343a2edeb81a67acc8f78ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->