### PR TITLE
Revert "Fix in-page pagination stuck on TOC in sliding-window mode"

### DIFF
--- a/docs/implemented/SLIDING_WINDOW_PAGINATION_STATUS.md
+++ b/docs/implemented/SLIDING_WINDOW_PAGINATION_STATUS.md
@@ -1,17 +1,5 @@
 # Sliding Window Pagination - Implementation Status
 
-## 2025-11-22 Update - In-Page Pagination Bug Fix
-
-- **TOC pagination bug resolved**: Fixed a critical issue where in-page pagination would get stuck on the Table of Contents when using sliding-window wrapped HTML in continuous mode.
-- **Root cause**: The JavaScript paginator's `wrapExistingContentAsSegment()` function was wrapping all pre-loaded HTML content (which already contained multiple `<section>` elements with `data-chapter-index` attributes from `ContinuousPaginatorWindowHtmlProvider`) into a single segment with chapter index 0. This caused navigation and chapter detection to fail.
-- **Solution implemented**:
-  - Modified `wrapExistingContentAsSegment()` to detect and preserve existing chapter sections from sliding-window HTML
-  - Updated `getCurrentChapter()` to use viewport center position for accurate chapter detection across multiple sections
-  - Fixed `getLoadedChapters()`, `jumpToChapter()`, and `getSegmentPageCount()` to use absolute positioning calculations
-  - All position calculations now properly handle multi-chapter content in a single WebView
-- **Backward compatibility**: The fix maintains full compatibility with chapter-based pagination mode, which still wraps single-chapter content as before
-- **Testing**: All existing unit tests pass, manual validation confirms the fix works for both modes
-
 ## 2025-11-20 Update
 
 - **Pagination engine hardening**: `ContinuousPaginator` now rebalances its start/end indices so the sliding window keeps its full configured size even when the user lands near the beginning or end of a book. This avoids unexpected fragment churn and matches the behavior expected by our older tests.


### PR DESCRIPTION
Reverts rifters/RiftedReader#161

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts sliding-window–specific handling in `inpage_paginator.js`, always wrapping content as a single segment and simplifying page/segment calculations; removes related docs note.
> 
> - **JS paginator (`app/src/main/assets/inpage_paginator.js`)**:
>   - Remove detection/preservation of existing chapter `<section data-chapter-index>` elements; always wrap body content into a single `chapter-segment`.
>   - Simplify page/segment math:
>     - Use positions relative to `contentWrapper` (`getBoundingClientRect`) with optional `scrollLeft` when needed in `getSegmentPageCount`, `jumpToChapter`, `getLoadedChapters`, and `getCurrentChapter`.
>   - Minor cleanup of comments/logs.
> - **Docs (`docs/implemented/SLIDING_WINDOW_PAGINATION_STATUS.md`)**:
>   - Remove the 2025-11-22 update section describing the in-page pagination bug fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab8429831e7fff7f6ce256ca349911e677fba38b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->