### PR TITLE
Revert "Enhance renderBaseContent for pagination modes"

### DIFF
--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt
@@ -942,116 +942,119 @@ class ReaderPageFragment : Fragment() {
     }
 
     private fun renderBaseContent() {
-    if (_binding == null) return
-
-    val mode = readerViewModel.paginationMode
-    val html = latestPageHtml
-
-    // [PAGINATION_DEBUG] Log render request details
-    com.rifters.riftedreader.util.AppLogger.d(
-        "ReaderPageFragment",
-        "[PAGINATION_DEBUG] renderBaseContent called: windowIndex=$windowIndex, " +
+        if (_binding == null) return
+        val html = latestPageHtml
+        
+        // [PAGINATION_DEBUG] Log render request details
+        com.rifters.riftedreader.util.AppLogger.d("ReaderPageFragment", 
+            "[PAGINATION_DEBUG] renderBaseContent called: windowIndex=$windowIndex, " +
             "hasHtml=${!html.isNullOrBlank()}, htmlLength=${html?.length ?: 0}, " +
-            "paginationMode=$mode"
-    )
-
-    if (mode == PaginationMode.CONTINUOUS) {
-        // CONTINUOUS MODE: always drive from window HTML, ignore latestPageHtml
-        binding.pageWebView.visibility = View.VISIBLE
-        binding.pageTextView.visibility = View.GONE
-
-        val settings = readerViewModel.readerSettings.value
-        val palette = ReaderThemePaletteResolver.resolve(requireContext(), settings.theme)
-
-        viewLifecycleOwner.lifecycleScope.launch {
-            try {
-                val windowPayload = readerViewModel.getWindowHtml(windowIndex)
-                if (windowPayload == null) {
-                    com.rifters.riftedreader.util.AppLogger.w(
-                        "ReaderPageFragment",
-                        "[PAGINATION_DEBUG] getWindowHtml returned null for windowIndex=$windowIndex; loading empty page"
+            "paginationMode=${readerViewModel.paginationMode}"
+        )
+        
+        if (!html.isNullOrBlank()) {
+            // Use WebView for rich HTML content (EPUB)
+            binding.pageWebView.visibility = View.VISIBLE
+            binding.pageTextView.visibility = View.GONE
+            
+            val settings = readerViewModel.readerSettings.value
+            val palette = ReaderThemePaletteResolver.resolve(requireContext(), settings.theme)
+            
+            // In continuous mode with streaming enabled, use window HTML
+            // Otherwise use the single chapter HTML as before
+            viewLifecycleOwner.lifecycleScope.launch {
+                try {
+                    val contentHtml = if (readerViewModel.paginationMode == PaginationMode.CONTINUOUS) {
+                        // Get window HTML containing multiple chapters
+                        // windowIndex is the RecyclerView position, directly used as window index
+                        val windowPayload = readerViewModel.getWindowHtml(windowIndex)
+                        if (windowPayload != null) {
+                            com.rifters.riftedreader.util.AppLogger.d("ReaderPageFragment", 
+                                "[PAGINATION_DEBUG] Using window HTML for windowIndex=$windowIndex: window=${windowPayload.windowIndex}, " +
+                                "firstChapter=${windowPayload.chapterIndex} (${windowPayload.windowSize} chapters per window, totalChapters=${windowPayload.totalChapters}), " +
+                                "htmlLength=${windowPayload.html.length}"
+                            )
+                            windowPayload.html
+                        } else {
+                            com.rifters.riftedreader.util.AppLogger.w("ReaderPageFragment", "[PAGINATION_DEBUG] Failed to get window HTML for windowIndex=$windowIndex, falling back to single chapter")
+                            html
+                        }
+                    } else {
+                        // Chapter-based mode: use single chapter HTML as before
+                        // In this mode, windowIndex equals chapter index
+                        com.rifters.riftedreader.util.AppLogger.d("ReaderPageFragment", 
+                            "[PAGINATION_DEBUG] Using chapter HTML for chapterIndex=$windowIndex, htmlLength=${html.length}"
+                        )
+                        html
+                    }
+                    
+                    // Wrap HTML with proper styling using ReaderHtmlWrapper
+                    val config = com.rifters.riftedreader.domain.reader.ReaderHtmlConfig(
+                        textSizePx = settings.textSizeSp,
+                        lineHeightMultiplier = settings.lineHeightMultiplier,
+                        palette = palette,
+                        enableDiagnostics = settings.paginationDiagnosticsEnabled
                     )
+                    val wrappedHtml = com.rifters.riftedreader.domain.reader.ReaderHtmlWrapper.wrap(contentHtml, config)
+                    
+                    // [PAGINATION_DEBUG] Log wrapped HTML size
+                    com.rifters.riftedreader.util.AppLogger.d("ReaderPageFragment", 
+                        "[PAGINATION_DEBUG] Wrapped HTML prepared: windowIndex=$windowIndex, wrappedLength=${wrappedHtml.length}, diagnostics=${settings.paginationDiagnosticsEnabled}"
+                    )
+                    
+                    // Log the wrapped HTML for debugging
+                    val chapterIndex = resolvedChapterIndex ?: windowIndex
+                    readerViewModel.bookId?.let { bookId ->
+                        com.rifters.riftedreader.util.HtmlDebugLogger.logWrappedHtml(
+                            bookId = bookId,
+                            chapterIndex = chapterIndex,
+                            wrappedHtml = wrappedHtml,
+                            metadata = mapOf(
+                                "windowIndex" to windowIndex.toString(),
+                                "textSize" to settings.textSizeSp.toString(),
+                                "lineHeight" to settings.lineHeightMultiplier.toString(),
+                                "theme" to settings.theme.name,
+                                "paginationMode" to readerViewModel.paginationMode.name,
+                                "diagnosticsEnabled" to settings.paginationDiagnosticsEnabled.toString()
+                            )
+                        )
+                    }
+                    
+                    // Bug Fix 2: Reset isWebViewReady flag when loading new content to prevent race conditions
+                    isWebViewReady = false
+                    // Reset paginator initialization flag - will be set to true in onPaginationReady callback
+                    isPaginatorInitialized = false
+                    
+                    // MEASUREMENT DISCIPLINE: Use doOnLayout to defer HTML loading until WebView is measured
+                    ensureMeasuredAndLoadHtml(wrappedHtml)
+                    
+                } catch (e: Exception) {
+                    com.rifters.riftedreader.util.AppLogger.e("ReaderPageFragment", "[PAGINATION_DEBUG] Error loading window HTML for windowIndex=$windowIndex, using fallback", e)
+                    // Fallback to old method if there's any error
+                    val wrappedHtml = wrapHtmlForWebView(html, settings.textSizeSp, settings.lineHeightMultiplier, palette)
+                    isWebViewReady = false
+                    isPaginatorInitialized = false
+                    val baseUrl = "https://${EpubImageAssetHelper.ASSET_HOST}/"
                     binding.pageWebView.loadDataWithBaseURL(
-                        "https://appassets.androidplatform.net/",
-                        "<html><body></body></html>",
-                        "text/html",
-                        "UTF-8",
+                        baseUrl, 
+                        wrappedHtml, 
+                        "text/html", 
+                        "UTF-8", 
                         null
                     )
-                    return@launch
                 }
-
-                val contentHtml = windowPayload.html
-
-                val config = com.rifters.riftedreader.domain.reader.ReaderHtmlConfig(
-                    textSizePx = settings.textSizeSp,
-                    lineHeightMultiplier = settings.lineHeightMultiplier,
-                    palette = palette,
-                    enableDiagnostics = settings.paginationDiagnosticsEnabled
-                )
-                val wrappedHtml =
-                    com.rifters.riftedreader.domain.reader.ReaderHtmlWrapper.wrap(contentHtml, config)
-
-                com.rifters.riftedreader.util.AppLogger.d(
-                    "ReaderPageFragment",
-                    "[PAGINATION_DEBUG] Continuous mode: loading window HTML for windowIndex=$windowIndex, " +
-                        "wrappedLength=${wrappedHtml.length}"
-                )
-
-                // Reset flags before loading
-                isWebViewReady = false
-                isPaginatorInitialized = false
-
-                ensureMeasuredAndLoadHtml(wrappedHtml)
-            } catch (e: Exception) {
-                com.rifters.riftedreader.util.AppLogger.e(
-                    "ReaderPageFragment",
-                    "[PAGINATION_DEBUG] Error loading window HTML for windowIndex=$windowIndex",
-                    e
-                )
             }
+        } else {
+            // Use TextView for plain text content (TXT)
+            com.rifters.riftedreader.util.AppLogger.d("ReaderPageFragment", 
+                "[PAGINATION_DEBUG] Using TextView for plain text: windowIndex=$windowIndex, textLength=${latestPageText.length}"
+            )
+            binding.pageWebView.visibility = View.GONE
+            binding.pageTextView.visibility = View.VISIBLE
+            binding.pageTextView.text = latestPageText
         }
-
-        return
     }
-
-    // CHAPTER-BASED MODE: existing behavior using latestPageHtml/latestPageText
-    if (!html.isNullOrBlank()) {
-        // Use WebView for rich HTML content (EPUB)
-        binding.pageWebView.visibility = View.VISIBLE
-        binding.pageTextView.visibility = View.GONE
-
-        val settings = readerViewModel.readerSettings.value
-        val palette = ReaderThemePaletteResolver.resolve(requireContext(), settings.theme)
-
-        // Chapter-based mode: use single chapter HTML as before
-        com.rifters.riftedreader.util.AppLogger.d(
-            "ReaderPageFragment",
-            "[PAGINATION_DEBUG] Using chapter HTML for chapterIndex=$windowIndex, htmlLength=${html.length}"
-        )
-
-        // Wrap HTML with proper styling using ReaderHtmlWrapper
-        val config = com.rifters.riftedreader.domain.reader.ReaderHtmlConfig(
-            textSizePx = settings.textSizeSp,
-            lineHeightMultiplier = settings.lineHeightMultiplier,
-            palette = palette,
-            enableDiagnostics = settings.paginationDiagnosticsEnabled
-        )
-        val wrappedHtml =
-            com.rifters.riftedreader.domain.reader.ReaderHtmlWrapper.wrap(html, config)
-
-        // Reset flags before loading
-        isWebViewReady = false
-        isPaginatorInitialized = false
-
-        ensureMeasuredAndLoadHtml(wrappedHtml)
-    } else {
-        // Fallback: plain text mode
-        binding.pageWebView.visibility = View.GONE
-        binding.pageTextView.visibility = View.VISIBLE
-        binding.pageTextView.text = latestPageText
-    }
-}
+    
     /**
      * Ensure WebView is measured (width/height > 0) before loading HTML.
      * Uses doOnLayout guard to defer loading until layout is complete.


### PR DESCRIPTION
Reverts rifters/RiftedReader#224

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors ReaderPageFragment rendering to load window HTML in continuous mode (with fallback to chapter HTML), wrap/stylize content, defer WebView loading until measured, and use asset-host base URLs; falls back to TextView for plain text.
> 
> - **ReaderPageFragment**:
>   - **Rendering logic**: Consolidates `renderBaseContent` to choose WebView for HTML (EPUB) and TextView for plain text, regardless of pagination mode.
>     - In `CONTINUOUS` mode, fetches window HTML via `getWindowHtml(windowIndex)`; falls back to single-chapter HTML if unavailable.
>     - In chapter-based mode, uses single chapter HTML.
>   - **HTML handling**:
>     - Wraps content via `ReaderHtmlWrapper` with settings (text size, line height, theme, diagnostics) and logs via `HtmlDebugLogger`.
>     - Resets `isWebViewReady`/`isPaginatorInitialized` before load; defers load until WebView is measured via `ensureMeasuredAndLoadHtml`.
>     - Loads with base URL `https://${EpubImageAssetHelper.ASSET_HOST}/` for asset resolution; updates fallback `loadDataWithBaseURL` accordingly.
>   - **Logging**: Adds detailed [PAGINATION_DEBUG] logs for decisions and sizes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cdf2429e640af52dfd9d47c320c2e06ff468fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->