### PR TITLE
Revert "Fix blank windows in PAGE + CONTINUOUS mode"

### DIFF
--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt
@@ -310,66 +310,32 @@ class ReaderPageFragment : Fragment() {
             setupWebViewSwipeHandling()
         }
         
-        // Content loading strategy differs by pagination mode:
-        // - CONTINUOUS mode: Content is loaded via getWindowHtml(windowIndex) in renderBaseContent()
-        //   The observePageContent() cache is keyed by global page index, not window index,
-        //   so we skip it and trigger render directly.
-        // - CHAPTER_BASED mode: Content is loaded via observePageContent(chapterIndex)
-        //   where pageIndex == chapterIndex (1:1 mapping)
-        if (readerViewModel.paginationMode == PaginationMode.CONTINUOUS) {
-            // CONTINUOUS mode: Trigger initial render once when fragment is created
-            // Content will be fetched via getWindowHtml(windowIndex) in renderBaseContent()
-            // 
-            // Note on position restoration: In CONTINUOUS mode, we preserve the in-page position
-            // (targetInPageIndex) across window navigation. This allows users to return to
-            // the exact in-page position when navigating back to a previously viewed window.
-            // In CHAPTER_BASED mode, each chapter always starts at page 0.
-            //
-            // We use repeatOnLifecycle with a guard condition to ensure the render
-            // only happens once per fragment creation, not on every STARTED transition.
-            viewLifecycleOwner.lifecycleScope.launch {
-                // Wait for STARTED state before rendering (aligns with other observers)
-                repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    // Only render once - this block will be skipped on subsequent STARTED transitions
-                    // because latestPageHtml will already be populated
-                    if (latestPageHtml.isNullOrBlank() && latestPageText.isBlank()) {
-                        // Reset state for new window
-                        ttsChunks = emptyList()
-                        currentInPageIndex = targetInPageIndex
-                        pendingInitialInPageIndex = targetInPageIndex.takeIf { it > 0 }
-                        isPaginatorInitialized = false
-                        
-                        // Render content - getWindowHtml() will be called inside renderBaseContent()
-                        if (highlightedRange == null) {
-                            renderBaseContent()
-                        } else {
-                            applyHighlight(highlightedRange)
-                        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                readerViewModel.observePageContent(pageIndex).collect { page ->
+                    if (page == PageContent.EMPTY && readerViewModel.paginationMode == PaginationMode.CONTINUOUS) {
+                        return@collect
                     }
-                }
-            }
-        } else {
-            // CHAPTER_BASED mode: Subscribe to page content cache
-            // In this mode, pageIndex == chapterIndex (1:1 mapping)
-            // Each chapter always starts at in-page index 0 (no position restoration across chapters)
-            viewLifecycleOwner.lifecycleScope.launch {
-                repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    readerViewModel.observePageContent(pageIndex).collect { page ->
-                        latestPageText = page.text
-                        latestPageHtml = page.html
+                    latestPageText = page.text
+                    latestPageHtml = page.html
 
-                        // Clear chunks when content changes - they'll be rebuilt by prepareTtsChunks
-                        ttsChunks = emptyList()
-                        // Reset in-page position for new content (chapters always start at page 0)
-                        currentInPageIndex = 0
-                        pendingInitialInPageIndex = null
-                        // Reset paginator initialization flag for new chapter content
-                        isPaginatorInitialized = false
-                        if (highlightedRange == null) {
-                            renderBaseContent()
-                        } else {
-                            applyHighlight(highlightedRange)
-                        }
+                    // Clear chunks when content changes - they'll be rebuilt by prepareTtsChunks
+                    ttsChunks = emptyList()
+                    // Reset in-page position for new content
+                    currentInPageIndex = if (readerViewModel.paginationMode == PaginationMode.CONTINUOUS) {
+                        targetInPageIndex
+                    } else {
+                        0
+                    }
+                    pendingInitialInPageIndex = targetInPageIndex.takeIf {
+                        readerViewModel.paginationMode == PaginationMode.CONTINUOUS && it > 0
+                    }
+                    // Reset paginator initialization flag for new chapter content
+                    isPaginatorInitialized = false
+                    if (highlightedRange == null) {
+                        renderBaseContent()
+                    } else {
+                        applyHighlight(highlightedRange)
                     }
                 }
             }


### PR DESCRIPTION
Reverts rifters/RiftedReader#223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies page content observation for both pagination modes, skipping EMPTY pages in continuous mode and standardizing state resets and rendering/highlighting behavior.
> 
> - **ReaderPageFragment**:
>   - **Content observation/loading**:
>     - Replace split CONTINUOUS vs CHAPTER_BASED logic with a single `observePageContent(pageIndex)` flow.
>     - Skip `PageContent.EMPTY` in `CONTINUOUS` mode to avoid processing empty updates.
>   - **State handling**:
>     - Standardize resets on content change: `ttsChunks`, `isPaginatorInitialized`.
>     - Set `currentInPageIndex` to `targetInPageIndex` in `CONTINUOUS`, else `0`.
>     - Set `pendingInitialInPageIndex` only in `CONTINUOUS` when `targetInPageIndex > 0`.
>   - **Rendering/Highlighting**:
>     - After updates, call `renderBaseContent()` or `applyHighlight(highlightedRange)` consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c13c0456320326ba47ef9976355f56443c832700. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->