### PR TITLE
Copilot/task1 conveyor routing v2

### DIFF
--- a/MINIMAL_PAGINATOR_INTEGRATION.md
+++ b/MINIMAL_PAGINATOR_INTEGRATION.md
@@ -1,0 +1,189 @@
+# Minimal Paginator Integration Guide
+
+## Overview
+
+The minimal paginator integration provides a robust, non-invasive pagination system that works alongside the existing conveyor belt and WindowBufferManager architecture. The integration is **feature-flagged** and disabled by default for backward compatibility.
+
+## Feature Flag
+
+### Location
+The feature flag is stored in **ReaderPreferences** as part of **ReaderSettings**.
+
+```kotlin
+// In ReaderSettings data class
+val enableMinimalPaginator: Boolean = false  // Default: disabled
+```
+
+### How to Enable/Disable
+
+#### Method 1: Via SharedPreferences (Programmatic)
+```kotlin
+// In your app code
+readerPreferences.updateSettings { settings ->
+    settings.copy(enableMinimalPaginator = true)
+}
+```
+
+#### Method 2: Via ADB (For Testing)
+```bash
+# Enable the feature
+adb shell "run-as com.rifters.riftedreader \
+  echo 'enable_minimal_paginator=true' >> \
+  /data/data/com.rifters.riftedreader/shared_prefs/reader_preferences.xml"
+
+# Disable the feature
+adb shell "run-as com.rifters.riftedreader \
+  echo 'enable_minimal_paginator=false' >> \
+  /data/data/com.rifters.riftedreader/shared_prefs/reader_preferences.xml"
+```
+
+#### Method 3: Temporary Toggle (For Development)
+You can temporarily hardcode the flag in `ReaderPreferences.kt`:
+
+```kotlin
+// In ReaderPreferences.readSettings()
+val enableMinimalPaginator = true  // Force enable for testing
+```
+
+**Remember to revert this change before committing!**
+
+## Architecture
+
+### Components
+
+1. **minimal_paginator.js**
+   - Location: `app/src/main/assets/minimal_paginator.js`
+   - Robust pagination with DOM/font/image stability detection
+   - Exposes `window.initPaginator(rootSelector)` for initialization
+   - Calls `PaginatorBridge.onPaginationReady(json)` when stable
+   - Calls `PaginatorBridge.onBoundary(json)` at window edges
+
+2. **PaginatorBridge.kt**
+   - Location: `app/src/main/java/com/rifters/riftedreader/ui/reader/PaginatorBridge.kt`
+   - JavascriptInterface that receives callbacks from JS
+   - Posts events to main thread
+   - Forwards to ReaderViewModel methods
+
+3. **ReaderPageFragment Integration**
+   - Location: `app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt`
+   - Registers `PaginatorBridge` as `"PaginatorBridge"` JavascriptInterface (when flag enabled)
+   - Calls `window.initPaginator('#window-root')` after HTML loads (when flag enabled)
+   - Handles boundary events via `handleMinimalPaginatorBoundary()`
+
+4. **ReaderViewModel Integration**
+   - Location: `app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderViewModel.kt`
+   - New method: `onWindowPaginationReady(windowIndex: Int, totalPages: Int)`
+   - Updates StateFlows and notifies WindowBufferManager
+
+## Behavior
+
+### When Feature Flag is DISABLED (default)
+- No PaginatorBridge is registered
+- No `window.initPaginator()` call is made
+- Existing pagination system operates normally
+- No performance impact
+
+### When Feature Flag is ENABLED
+- PaginatorBridge is registered to WebView before HTML load
+- After HTML loads, `window.initPaginator('#window-root')` is called
+- minimal_paginator.js waits for stable layout (DOM + fonts + images)
+- When stable and totalPages > 0, calls `onPaginationReady`
+- When user reaches window boundaries, calls `onBoundary`
+- Boundary events trigger existing navigation logic (navigateToNextPage/navigateToPreviousPage)
+
+## Logging
+
+All minimal paginator events are logged with distinct prefixes for easy filtering:
+
+### JavaScript Console Logs
+Prefix: `[MIN_PAGINATOR:TAG]`
+
+Examples:
+```
+[MIN_PAGINATOR:INIT] initPaginator called with selector: #window-root
+[MIN_PAGINATOR:INIT_SUCCESS] pageCount=45, charOffsets=45
+[MIN_PAGINATOR:BOUNDARY] Reached FORWARD boundary
+```
+
+Filter in Chrome DevTools:
+```
+MIN_PAGINATOR
+```
+
+### Android Logcat
+Tag: `PaginatorBridge`, `ReaderPageFragment`, `ReaderViewModel`
+
+Filter examples:
+```bash
+# All paginator-related logs
+adb logcat | grep -E "MIN_PAGINATOR|PaginatorBridge"
+
+# Only pagination ready events
+adb logcat | grep "PAGINATION_READY"
+
+# Only boundary events
+adb logcat | grep "BOUNDARY"
+```
+
+## Testing Checklist
+
+### With Feature Flag OFF (default)
+- [ ] Open a book - should behave like current development branch
+- [ ] Navigate between pages - no console errors
+- [ ] Check logcat - no PaginatorBridge messages
+- [ ] Window transitions work normally
+
+### With Feature Flag ON
+- [ ] Open a book (e.g., "Hell Difficulty Tutorial 2")
+- [ ] Check logcat for:
+  - `[MIN_PAGINATOR] Registered PaginatorBridge for windowIndex=X`
+  - `[MIN_PAGINATOR] Called window.initPaginator for windowIndex=X`
+  - `[PAGINATION_READY] windowIndex=X, pageCount=Y` (Y should be > 0)
+- [ ] Navigate to last page in window
+- [ ] Swipe/tap next - should trigger boundary event
+- [ ] Check logcat for: `[BOUNDARY] windowIndex=X, direction=NEXT`
+- [ ] Verify window transition occurs (conveyor shift)
+- [ ] Navigate to first page in window
+- [ ] Swipe/tap previous - should trigger boundary event
+- [ ] Check logcat for: `[BOUNDARY] windowIndex=X, direction=PREVIOUS`
+- [ ] Verify backward window transition occurs
+
+## Known Issues / TODOs
+
+1. **WindowBufferManager Integration**: The `onWindowPaginationReady` method currently logs and updates state but doesn't fully signal the buffer manager. This will be completed when the conveyor system requires explicit pagination-ready signals for phase transitions.
+
+2. **Console Message Capture**: WebView console messages from minimal_paginator.js could be captured via WebChromeClient for better diagnostics. This is optional and not implemented yet.
+
+3. **Character Offset Support**: The minimal paginator tracks character offsets for bookmarks/progress, but this isn't wired to the bookmark system yet.
+
+## Future Enhancements
+
+When the feature is stable and proven:
+1. Change default to `true` in ReaderSettings
+2. Add UI toggle in Reader Settings screen
+3. Wire character offset tracking to bookmark system
+4. Full WindowBufferManager conveyor integration
+5. Remove feature flag once fully adopted
+
+## Code Locations
+
+| File | Purpose |
+|------|---------|
+| `app/src/main/assets/minimal_paginator.js` | JavaScript pagination engine |
+| `app/src/main/java/com/rifters/riftedreader/ui/reader/PaginatorBridge.kt` | JS-to-Kotlin bridge |
+| `app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt` | Bridge registration & initialization |
+| `app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderViewModel.kt` | `onWindowPaginationReady()` handler |
+| `app/src/main/java/com/rifters/riftedreader/data/preferences/ReaderPreferences.kt` | Feature flag storage |
+
+## Support
+
+For issues or questions about the minimal paginator integration:
+1. Check the logs with filters above
+2. Verify feature flag state
+3. Compare behavior with flag on vs off
+4. Review this document for expected behavior
+
+---
+
+**Last Updated**: 2025-12-07  
+**Status**: Implemented, Feature-Flagged (Default: OFF)

--- a/app/src/main/assets/minimal_paginator.js
+++ b/app/src/main/assets/minimal_paginator.js
@@ -130,6 +130,16 @@
             if (state.isPaginationReady) {
                 log('INIT_SUCCESS', `pageCount=${state.pageCount}, charOffsets=${charOffsets.length}`);
                 callAndroidBridge('onPaginationReady', { pageCount: state.pageCount });
+                
+                // Dispatch DOM CustomEvent for other consumers
+                try {
+                    const event = new CustomEvent('paginator-ready', {
+                        detail: { pageCount: state.pageCount, windowIndex: config.windowIndex }
+                    });
+                    document.dispatchEvent(event);
+                } catch (e) {
+                    log('ERROR', `Failed to dispatch paginator-ready event: ${e.message}`);
+                }
             } else {
                 log('INIT_INCOMPLETE', 'Pagination not ready');
             }
@@ -396,6 +406,15 @@
             if (window.AndroidBridge && typeof window.AndroidBridge.onBoundaryReached === 'function') {
                 window.AndroidBridge.onBoundaryReached('NEXT', state.currentPage, state.pageCount);
             }
+            // Dispatch DOM CustomEvent for other consumers
+            try {
+                const event = new CustomEvent('paginator-boundary', {
+                    detail: { direction: 'NEXT', windowIndex: config.windowIndex }
+                });
+                document.dispatchEvent(event);
+            } catch (e) {
+                log('ERROR', `Failed to dispatch boundary event: ${e.message}`);
+            }
             lastBoundaryDirection = 'FORWARD';
             log('BOUNDARY', 'Reached FORWARD boundary');
         } else if (currentProgress <= (1 - BOUNDARY_THRESHOLD) && lastBoundaryDirection !== 'BACKWARD') {
@@ -404,6 +423,15 @@
             // Also call legacy onBoundaryReached for backward compatibility
             if (window.AndroidBridge && typeof window.AndroidBridge.onBoundaryReached === 'function') {
                 window.AndroidBridge.onBoundaryReached('PREVIOUS', state.currentPage, state.pageCount);
+            }
+            // Dispatch DOM CustomEvent for other consumers
+            try {
+                const event = new CustomEvent('paginator-boundary', {
+                    detail: { direction: 'PREVIOUS', windowIndex: config.windowIndex }
+                });
+                document.dispatchEvent(event);
+            } catch (e) {
+                log('ERROR', `Failed to dispatch boundary event: ${e.message}`);
             }
             lastBoundaryDirection = 'BACKWARD';
             log('BOUNDARY', 'Reached BACKWARD boundary');

--- a/app/src/main/java/com/rifters/riftedreader/data/preferences/ReaderPreferences.kt
+++ b/app/src/main/java/com/rifters/riftedreader/data/preferences/ReaderPreferences.kt
@@ -59,9 +59,10 @@ data class ReaderSettings(
      * - Provides explicit boundary detection for window transitions
      * - Ensures totalPages > 0 before reporting ready (avoids race conditions)
      * 
-     * Default is false for backward compatibility. Enable for testing/QA.
+     * Default is true for development. All QA and dev work tests the new pipeline.
+     * Can be toggled to false via ADB or code for legacy paginator testing.
      */
-    val enableMinimalPaginator: Boolean = false
+    val enableMinimalPaginator: Boolean = true
 )
 
 enum class ReaderTheme {
@@ -105,7 +106,7 @@ class ReaderPreferences(context: Context) {
         val streamingEnabled = prefs.getBoolean(KEY_CONTINUOUS_STREAMING, true)
         val diagnosticsEnabled = prefs.getBoolean(KEY_PAGINATION_DIAGNOSTICS, false)
         val debugWindowRendering = prefs.getBoolean(KEY_DEBUG_WINDOW_RENDERING, false)
-        val enableMinimalPaginator = prefs.getBoolean(KEY_ENABLE_MINIMAL_PAGINATOR, false)
+        val enableMinimalPaginator = prefs.getBoolean(KEY_ENABLE_MINIMAL_PAGINATOR, true)
         
         // Read chapter visibility settings
         val includeCover = prefs.getBoolean(KEY_INCLUDE_COVER, false)

--- a/app/src/main/java/com/rifters/riftedreader/data/preferences/ReaderPreferences.kt
+++ b/app/src/main/java/com/rifters/riftedreader/data/preferences/ReaderPreferences.kt
@@ -50,7 +50,18 @@ data class ReaderSettings(
      * 
      * Only active in debug builds. Default is false.
      */
-    val debugWindowRenderingEnabled: Boolean = false
+    val debugWindowRenderingEnabled: Boolean = false,
+    /**
+     * Feature flag to enable the minimal paginator integration.
+     * When enabled:
+     * - Uses robust minimal_paginator.js with improved stability detection
+     * - Registers PaginatorBridge for pagination-ready and boundary events
+     * - Provides explicit boundary detection for window transitions
+     * - Ensures totalPages > 0 before reporting ready (avoids race conditions)
+     * 
+     * Default is false for backward compatibility. Enable for testing/QA.
+     */
+    val enableMinimalPaginator: Boolean = false
 )
 
 enum class ReaderTheme {
@@ -94,6 +105,7 @@ class ReaderPreferences(context: Context) {
         val streamingEnabled = prefs.getBoolean(KEY_CONTINUOUS_STREAMING, true)
         val diagnosticsEnabled = prefs.getBoolean(KEY_PAGINATION_DIAGNOSTICS, false)
         val debugWindowRendering = prefs.getBoolean(KEY_DEBUG_WINDOW_RENDERING, false)
+        val enableMinimalPaginator = prefs.getBoolean(KEY_ENABLE_MINIMAL_PAGINATOR, false)
         
         // Read chapter visibility settings
         val includeCover = prefs.getBoolean(KEY_INCLUDE_COVER, false)
@@ -114,7 +126,8 @@ class ReaderPreferences(context: Context) {
             continuousStreamingEnabled = streamingEnabled,
             paginationDiagnosticsEnabled = diagnosticsEnabled,
             chapterVisibility = chapterVisibility,
-            debugWindowRenderingEnabled = debugWindowRendering
+            debugWindowRenderingEnabled = debugWindowRendering,
+            enableMinimalPaginator = enableMinimalPaginator
         )
     }
 
@@ -128,6 +141,7 @@ class ReaderPreferences(context: Context) {
             putBoolean(KEY_CONTINUOUS_STREAMING, settings.continuousStreamingEnabled)
             putBoolean(KEY_PAGINATION_DIAGNOSTICS, settings.paginationDiagnosticsEnabled)
             putBoolean(KEY_DEBUG_WINDOW_RENDERING, settings.debugWindowRenderingEnabled)
+            putBoolean(KEY_ENABLE_MINIMAL_PAGINATOR, settings.enableMinimalPaginator)
             
             // Save chapter visibility settings
             putBoolean(KEY_INCLUDE_COVER, settings.chapterVisibility.includeCover)
@@ -181,6 +195,7 @@ class ReaderPreferences(context: Context) {
         private const val KEY_CONTINUOUS_STREAMING = "continuous_streaming_enabled"
         private const val KEY_PAGINATION_DIAGNOSTICS = "pagination_diagnostics_enabled"
         private const val KEY_DEBUG_WINDOW_RENDERING = "debug_window_rendering_enabled"
+        private const val KEY_ENABLE_MINIMAL_PAGINATOR = "enable_minimal_paginator"
         private const val KEY_TAP_ACTIONS = "reader_tap_actions"
         
         // Chapter visibility settings keys

--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/PaginatorBridge.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/PaginatorBridge.kt
@@ -1,0 +1,97 @@
+package com.rifters.riftedreader.ui.reader
+
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import com.rifters.riftedreader.util.AppLogger
+import org.json.JSONObject
+
+/**
+ * JavascriptInterface bridge for minimal_paginator.js callbacks.
+ * 
+ * This bridge receives pagination-ready and boundary events from the robust
+ * minimal paginator implementation. It ensures stable pagination (totalPages > 0)
+ * and provides explicit boundary detection for window transitions.
+ * 
+ * Callbacks:
+ * - onPaginationReady: Called when pagination is stable with totalPages > 0
+ * - onBoundary: Called when user reaches window boundaries (NEXT/PREVIOUS)
+ * 
+ * Events are posted to main thread before forwarding to supplied callbacks.
+ */
+class PaginatorBridge(
+    private val windowIndex: Int,
+    private val onPaginationReady: (windowIndex: Int, totalPages: Int) -> Unit,
+    private val onBoundary: (windowIndex: Int, direction: String) -> Unit
+) {
+    
+    private val mainHandler = Handler(Looper.getMainLooper())
+    
+    /**
+     * Called by minimal_paginator.js when pagination is ready and stable.
+     * The paginator ensures totalPages > 0 before calling this method.
+     * 
+     * @param json JSON string containing pagination state: { "pageCount": N }
+     */
+    @JavascriptInterface
+    fun onPaginationReady(json: String) {
+        try {
+            val jsonObj = JSONObject(json)
+            val pageCount = jsonObj.optInt("pageCount", -1)
+            
+            AppLogger.d(
+                TAG,
+                "[PAGINATION_READY] windowIndex=$windowIndex, pageCount=$pageCount"
+            )
+            
+            if (pageCount > 0) {
+                mainHandler.post {
+                    onPaginationReady(windowIndex, pageCount)
+                }
+            } else {
+                AppLogger.w(
+                    TAG,
+                    "[PAGINATION_READY] Ignoring invalid pageCount=$pageCount for windowIndex=$windowIndex"
+                )
+            }
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "[PAGINATION_READY] Error parsing JSON: $json", e)
+        }
+    }
+    
+    /**
+     * Called by minimal_paginator.js when user attempts to navigate past window boundaries.
+     * Direction can be "NEXT" or "PREVIOUS".
+     * 
+     * @param json JSON string containing boundary info: { "direction": "NEXT"|"PREVIOUS" }
+     */
+    @JavascriptInterface
+    fun onBoundary(json: String) {
+        try {
+            val jsonObj = JSONObject(json)
+            val direction = jsonObj.optString("direction", "")
+            
+            AppLogger.d(
+                TAG,
+                "[BOUNDARY] windowIndex=$windowIndex, direction=$direction"
+            )
+            
+            if (direction.isNotEmpty()) {
+                mainHandler.post {
+                    onBoundary(windowIndex, direction)
+                }
+            } else {
+                AppLogger.w(
+                    TAG,
+                    "[BOUNDARY] Ignoring boundary event with empty direction for windowIndex=$windowIndex"
+                )
+            }
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "[BOUNDARY] Error parsing JSON: $json", e)
+        }
+    }
+    
+    companion object {
+        private const val TAG = "PaginatorBridge"
+    }
+}

--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderActivity.kt
@@ -39,6 +39,7 @@ import com.rifters.riftedreader.domain.tts.TTSService
 import com.rifters.riftedreader.domain.tts.TTSStatusNotifier
 import com.rifters.riftedreader.domain.tts.TTSStatusSnapshot
 import com.rifters.riftedreader.ui.reader.ReaderThemePaletteResolver
+import com.rifters.riftedreader.ui.reader.conveyor.ConveyorBeltSystemViewModel
 import com.rifters.riftedreader.ui.reader.conveyor.ConveyorDebugActivity
 import com.rifters.riftedreader.ui.tts.TTSControlsBottomSheet
 import com.rifters.riftedreader.util.AppLogger
@@ -53,6 +54,7 @@ class ReaderActivity : AppCompatActivity(), ReaderPreferencesOwner {
     
     private lateinit var binding: ActivityReaderBinding
     private lateinit var viewModel: ReaderViewModel
+    private lateinit var conveyorBeltSystem: ConveyorBeltSystemViewModel
     private lateinit var gestureDetector: GestureDetector
     private lateinit var controlsManager: ReaderControlsManager
     override lateinit var readerPreferences: ReaderPreferences
@@ -120,6 +122,18 @@ class ReaderActivity : AppCompatActivity(), ReaderPreferencesOwner {
         
         val factory = ReaderViewModel.Factory(bookId, bookFile, parser, repository, readerPreferences)
         viewModel = ViewModelProvider(this, factory)[ReaderViewModel::class.java]
+        
+        // Instantiate and wire ConveyorBeltSystemViewModel for minimal paginator integration
+        conveyorBeltSystem = ConveyorBeltSystemViewModel()
+        viewModel.setConveyorBeltSystem(conveyorBeltSystem)
+        
+        // Log startup information about minimal paginator default state
+        val enabledStatus = if (readerPreferences.settings.value.enableMinimalPaginator) "ENABLED" else "DISABLED"
+        AppLogger.d(
+            "ReaderActivity",
+            "[MINIMAL_PAGINATOR_DEFAULT] Minimal paginator is now DEFAULT for development: $enabledStatus. " +
+            "ConveyorBeltSystemViewModel wired to ReaderViewModel. Toggle via ADB if needed."
+        )
         
         // Debug log: assert initial pagination mode and window count
         AppLogger.d(

--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderPageFragment.kt
@@ -163,6 +163,13 @@ class ReaderPageFragment : Fragment() {
                 val minimalPaginatorBridge = PaginatorBridge(
                     windowIndex = windowIndex,
                     onPaginationReady = { wIdx, totalPages ->
+                        // Set paginator initialized flag (same as existing PaginationBridge)
+                        isPaginatorInitialized = true
+                        com.rifters.riftedreader.util.AppLogger.d(
+                            "ReaderPageFragment",
+                            "[MIN_PAGINATOR] isPaginatorInitialized set to true for windowIndex=$wIdx"
+                        )
+                        // Forward to ViewModel for state updates and conveyor integration
                         readerViewModel.onWindowPaginationReady(wIdx, totalPages)
                     },
                     onBoundary = { wIdx, direction ->

--- a/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/com/rifters/riftedreader/ui/reader/ReaderViewModel.kt
@@ -26,6 +26,7 @@ import com.rifters.riftedreader.pagination.SlidingWindowPaginator
 import com.rifters.riftedreader.pagination.WindowBufferManager
 import com.rifters.riftedreader.pagination.WindowData
 import com.rifters.riftedreader.pagination.WindowSyncHelpers
+import com.rifters.riftedreader.ui.reader.conveyor.ConveyorBeltSystemViewModel
 import com.rifters.riftedreader.util.AppLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -151,6 +152,14 @@ class ReaderViewModel(
     // Public accessor for fragments that need to check buffer state
     val windowBufferManager: WindowBufferManager?
         get() = _windowBufferManager
+    
+    // Conveyor Belt System for managing window transitions and buffer state
+    // This is the primary window controller in development branch
+    private var _conveyorBeltSystem: ConveyorBeltSystemViewModel? = null
+    
+    // Public accessor for conveyor system
+    val conveyorBeltSystem: ConveyorBeltSystemViewModel?
+        get() = _conveyorBeltSystem
     
     private var windowAssembler: DefaultWindowAssembler? = null
     
@@ -893,6 +902,18 @@ class ReaderViewModel(
     }
     
     /**
+     * Set the conveyor belt system instance.
+     * This should be called early in the reader lifecycle to enable
+     * conveyor-based window management for the minimal paginator.
+     * 
+     * @param conveyorSystem The ConveyorBeltSystemViewModel instance
+     */
+    fun setConveyorBeltSystem(conveyorSystem: ConveyorBeltSystemViewModel) {
+        _conveyorBeltSystem = conveyorSystem
+        AppLogger.d("ReaderViewModel", "[CONVEYOR] Conveyor belt system reference set")
+    }
+    
+    /**
      * Called by PaginatorBridge when pagination is ready and stable.
      * This is the entry point for the minimal paginator integration.
      * 
@@ -902,6 +923,9 @@ class ReaderViewModel(
      * 
      * This method performs the same state updates as the existing PaginationBridge
      * but with the guarantee of stable, non-zero page counts.
+     * 
+     * When the conveyor belt system is set, this method notifies it that the window
+     * has completed stable pagination, allowing for proper phase transitions.
      * 
      * @param windowIndex The window index that completed pagination
      * @param totalPages The total page count for the window (guaranteed > 0)
@@ -953,13 +977,21 @@ class ReaderViewModel(
                 }
             }
             
-            // The WindowBufferManager/conveyor system receives window navigation events
-            // via onEnteredWindow and maybeShiftForward, which are already wired.
-            // The stable totalPages ensures those methods work with accurate data.
-            AppLogger.d(
+            // Notify the conveyor belt system that this window has stable pagination
+            _conveyorBeltSystem?.let { conveyor ->
+                AppLogger.d(
+                    "ReaderViewModel",
+                    "[MIN_PAGINATOR] Notifying conveyor system: onWindowEntered($windowIndex)"
+                )
+                conveyor.onWindowEntered(windowIndex)
+                AppLogger.d(
+                    "ReaderViewModel",
+                    "[MIN_PAGINATOR] Conveyor notified - phase=${conveyor.phase.value}, " +
+                    "buffer=${conveyor.buffer.value}, activeWindow=${conveyor.activeWindow.value}"
+                )
+            } ?: AppLogger.d(
                 "ReaderViewModel",
-                "[MIN_PAGINATOR] Stable pagination ready for conveyor system - " +
-                "window=$windowIndex has $totalPages pages ready for navigation"
+                "[MIN_PAGINATOR] No conveyor system set - skipping conveyor notification"
             )
         } else {
             AppLogger.d(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a feature-flagged minimal paginator wired to the conveyor system via a new JS–Kotlin bridge, enabling stable pagination events and boundary-driven navigation by default in dev/QA.
> 
> - **Reader Pipeline (Feature-flagged, default ON)**
>   - Adds `ReaderSettings.enableMinimalPaginator` in `ReaderPreferences.kt` with persistence key `enable_minimal_paginator`.
>   - Wires `ConveyorBeltSystemViewModel` in `ReaderActivity` and logs flag state.
> - **JS Paginator (`app/src/main/assets/minimal_paginator.js`)**
>   - Prefers `window.PaginatorBridge` with JSON payloads; falls back to `AndroidBridge`.
>   - Emits `onPaginationReady` (only when `pageCount > 0`) and `onBoundary` (NEXT/PREVIOUS).
>   - Dispatches DOM events `paginator-ready` and `paginator-boundary`.
>   - Adds helpers: `window.initPaginator()`, `window.paginatorRecheck()`, `window.paginatorStop()`.
> - **Bridge & Fragment Integration**
>   - New `PaginatorBridge.kt` (`@JavascriptInterface`) posts to main thread and forwards:
>     - `onPaginationReady(pageCount)` → ViewModel
>     - `onBoundary(direction)` → Fragment navigation
>   - `ReaderPageFragment`:
>     - Registers `PaginatorBridge` when flag enabled; configures and calls `window.initPaginator(...)` after load.
>     - Handles boundary via `handleMinimalPaginatorBoundary()` and cleans up interfaces on destroy (`paginatorStop`).
> - **ViewModel (`ReaderViewModel.kt`)**
>   - New `setConveyorBeltSystem(...)` and `onWindowPaginationReady(windowIndex, totalPages)`.
>   - Updates webview page state/metrics and calls `conveyor.onWindowEntered(windowIndex)` for phase/buffer management.
> - **Docs**
>   - Adds `MINIMAL_PAGINATOR_INTEGRATION.md` covering architecture, flag, behavior, logging, testing checklist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2585a62e472f60cc13153e004654d2ba5c783745. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->