### PR TITLE
Revert "Restore responsive viewport while preserving pagination calculations"

### DIFF
--- a/app/src/main/assets/minimal_paginator.js
+++ b/app/src/main/assets/minimal_paginator.js
@@ -170,29 +170,9 @@
             // This is required for column layout to work correctly
             wrapExistingContentAsSegment();
             
-            // Try to read the injected physical viewport width from CSS custom property
-            // This is injected by ReaderHtmlWrapper.kt as --viewport-width-px
-            var rootStyle = getComputedStyle(document.documentElement);
-            var injectedWidth = rootStyle.getPropertyValue('--viewport-width-px');
-            
-            if (injectedWidth) {
-                var parsedWidth = parseInt(injectedWidth, 10);
-                if (!isNaN(parsedWidth) && parsedWidth > 0) {
-                    log('INIT', 'Using injected viewport width from CSS custom property: ' + parsedWidth + 'px');
-                    state.viewportWidth = parsedWidth;
-                    state.appliedColumnWidth = parsedWidth;
-                } else {
-                    // Fallback to window.innerWidth if parsing failed
-                    log('INIT', 'Failed to parse injected viewport width, falling back to window.innerWidth');
-                    state.viewportWidth = window.innerWidth;
-                    state.appliedColumnWidth = state.viewportWidth;
-                }
-            } else {
-                // Fallback to window.innerWidth if custom property not found
-                log('INIT', 'No injected viewport width found, using window.innerWidth');
-                state.viewportWidth = window.innerWidth;
-                state.appliedColumnWidth = state.viewportWidth;
-            }
+            // Use window.innerWidth as viewport width (container will be full width)
+            state.viewportWidth = window.innerWidth;
+            state.appliedColumnWidth = state.viewportWidth;
             
             log('INIT', `Using measured content width: ${state.viewportWidth}px (clientWidth=${state.contentWrapper.clientWidth}, boundingWidth=${state.contentWrapper.getBoundingClientRect().width})`);
             

--- a/app/src/main/java/com/rifters/riftedreader/domain/reader/ReaderHtmlWrapper.kt
+++ b/app/src/main/java/com/rifters/riftedreader/domain/reader/ReaderHtmlWrapper.kt
@@ -158,11 +158,8 @@ object ReaderHtmlWrapper {
             <html>
             <head>
                 <meta charset="utf-8"/>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes">
+                <meta name="viewport" content="width=${config.webViewWidthPx}, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes">
                 <style>
-                    :root {
-                        --viewport-width-px: ${config.webViewWidthPx}px;
-                    }
                     html, body {
                         margin: 0;
                         padding: 0;


### PR DESCRIPTION
Reverts rifters/RiftedReader#283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use explicit WebView width in meta tag and compute pagination using window.innerWidth, removing CSS custom property injection.
> 
> - **Reader HTML wrapper (`ReaderHtmlWrapper.kt`)**:
>   - Set `<meta name="viewport" content="width=${config.webViewWidthPx}, ...">`.
>   - Removed `:root` CSS custom property injection of `--viewport-width-px`.
> - **Minimal paginator (`app/src/main/assets/minimal_paginator.js`)**:
>   - Use `window.innerWidth` for `state.viewportWidth`/`appliedColumnWidth` instead of reading `--viewport-width-px` from CSS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7426b147034eefc4d597f59aa4d8da1edadd2d5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->